### PR TITLE
[languages.php] Added Beeflang to list of bindings

### DIFF
--- a/languages.php
+++ b/languages.php
@@ -32,6 +32,13 @@
                                 SDLAda -
                                 <a href="https://github.com/Lucretia/sdlada">https://github.com/Lucretia/sdlada</a>
                             </li>
+			    <li> <strong>
+                                    Beeflang
+                                </strong>
+                                <br/>
+                                BeefLibs SDL2 -
+                                <a href="https://github.com/beefytech/Beef/tree/master/BeefLibs/SDL2">https://github.com/beefytech/Beef/tree/master/BeefLibs/SDL2</a>
+                            </li>
                             <li> <strong>
                                     C#
                                 </strong>


### PR DESCRIPTION
I simply just added an entry for the beef programming language [https://github.com/beefytech/Beef](url) .
The sdl2 bindings are based on the c# version and are distributed with the basic installation of beef [https://github.com/beefytech/Beef/tree/master/BeefLibs/SDL2](url). 
So while they dont need to be downloaded additionally I would still say that it makes sense to add them here, as its still a binding for the language.