### PR TITLE
Update SDL_ts link in languages.php

### DIFF
--- a/languages.php
+++ b/languages.php
@@ -126,7 +126,7 @@
                                 </strong>
                                 <br/>
                                 SDL_ts -
-                                <a href="https://deno.land/x/sdl_ts@0.0.6">https://deno.land/x/sdl_ts@0.0.6</a>
+                                <a href="https://github.com/smack0007/SDL_ts">https://github.com/smack0007/SDL_ts</a>
                             </li>
                         </ul>
                     </blockquote>


### PR DESCRIPTION
Hi I'm the maintainer of SDL_ts and I'm glad @jingkaimori took the time to add this here but I would prefer the link pointed to the GitHub repo. The current link points to a specific version of SDL_ts and I haven't updated that place in 8 months at this point.