### PR TITLE
Relocating the vala bindings to its new home

### DIFF
--- a/languages.php
+++ b/languages.php
@@ -88,7 +88,7 @@
                                 </strong>
                                 <br/>
                                 sdl3-vapi -
-                                <a href="https://github.com/edwood-grant/sdl3-vapi">https://github.com/edwood-grant/sdl3-vapi</a>
+                                <a href="https://codeberg.org/edwood-grant/sdl3-vapi">https://codeberg.org/edwood-grant/sdl3-vapi</a>
                             </li>
                         </ul>
                     </blockquote>


### PR DESCRIPTION
The SDL3 Vala bingings git repository home has changed to Codeberg.
https://codeberg.org/edwood-grant/sdl3-vapi

This pull requests aims to update the Vala bindings URL to its new home.

Thanks a lot.