### PR TITLE
Add LWJGL's SDL3 Java bindings to the list

### DIFF
--- a/languages.php
+++ b/languages.php
@@ -67,6 +67,13 @@
                                 <a href="https://github.com/Zyko0/go-sdl3">https://github.com/Zyko0/go-sdl3</a>
                             </li>
                             <li> <strong>
+                                    Java
+                                </strong>
+                                <br/>
+                                LWJGL -
+                                <a href="https://github.com/LWJGL/lwjgl3">https://github.com/LWJGL/lwjgl3</a>
+                            </li>
+                            <li> <strong>
                                     Nim
                                 </strong>
                                 <br/>


### PR DESCRIPTION
LWJGL 3.4.0 has just released with SDL3 3.4.0 bindings for Java (and thus also any other JVM languages which can access Java APIs): https://github.com/LWJGL/lwjgl3/releases/tag/3.4.0

There is also a sample: https://github.com/LWJGL/lwjgl3/blob/master/modules/samples/src/test/java/org/lwjgl/demo/sdl/Gears.java